### PR TITLE
Add recaps to show page and vote page

### DIFF
--- a/world_stage/routes/vote.py
+++ b/world_stage/routes/vote.py
@@ -144,7 +144,8 @@ def vote(show: str):
     return render_template('vote/vote.html',
                            songs=songs, points=show_data.points, selected=selected,
                            username=username, nickname=nickname, country=country,
-                           year=show_data.year, show_name=show_data.name, show=show,
+                           year=show_data.year, show_name=show_data.name, 
+                           short_name=show_data.short_name, show=show,
                            selected_country=country_id, countries=get_countries(),
                            vote_count=get_vote_count_for_show(show_data.id))
 

--- a/world_stage/routes/year.py
+++ b/world_stage/routes/year.py
@@ -140,7 +140,7 @@ def results(year: str, show: str):
 
     return render_template('year/summary.html', hidden=reveal,
                            songs=songs, points=show_data.points, show=show, access=access, offset=off,
-                           show_name=show_data.name, show_id=show_data.id, year=year, participants=len(songs))
+                           show_name=show_data.name, short_name=show_data.short_name, show_id=show_data.id, year=year, participants=len(songs))
 
 @bp.get('/<year>/<show>/detailed')
 def detailed_results(year: str, show: str):

--- a/world_stage/templates/vote/vote.html
+++ b/world_stage/templates/vote/vote.html
@@ -55,6 +55,11 @@
         {% endfor %}
         </fieldset>
     </div>
+     <fieldset class="grid">
+            <legend>Recap</legend>
+            {% set url = "https://funcall.me/data/recaps/" ~ year ~ short_name ~ ".mp4" %}
+            <video width="560" height="315" controls><source src="{{ url }}" type="video/mp4">Your browser does not support the video tag.</video>
+    </fieldset>
     <div>
         <button type="submit">Submit</button>
     </div>

--- a/world_stage/templates/year/summary.html
+++ b/world_stage/templates/year/summary.html
@@ -60,6 +60,11 @@
             </tr>
         {% endfor %}
 </table>
+     <fieldset class="grid">
+            <legend>Recap</legend>
+            {% set url = "https://funcall.me/data/recaps/" ~ year ~ short_name ~ ".mp4" %}
+            <video width="560" height="315" controls><source src="{{ url }}" type="video/mp4">Your browser does not support the video tag.</video>
+    </fieldset>
 </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Adds a recap video to each show page and to the voting page

https://github.com/user-attachments/assets/35e73ee0-f8c8-4be9-bbbd-637815e91ccd

The years with no recaps will show an empty video. Same for specials, since those require special naming cases and it's potentially easier to just rename the files on the data. 

https://github.com/user-attachments/assets/3e565e21-9fc4-4b11-8847-bbc1b0861e86

