### PR TITLE
Placeholder value correctly shown in entry details

### DIFF
--- a/world_stage/templates/country/details.html
+++ b/world_stage/templates/country/details.html
@@ -40,7 +40,7 @@
         </tr>
         <tr>
             <th>Placeholder</th>
-            <td>{{ "Yes" if song.is_placeholder else "No" }}</td>
+            <td>{{ "Yes" if song.placeholder else "No" }}</td>
         </tr>
         <tr>
             <th>Recap start</th>


### PR DESCRIPTION
Placeholder value will be correctly shown in the entry details page. A wrongly called attribute was causing this

Before
![image](https://github.com/user-attachments/assets/3806e37d-d530-4705-980c-a8e588478e40)

After
![image](https://github.com/user-attachments/assets/2fa7e196-18e3-4f48-8eef-ca18333510a2)
