### PR TITLE
Adds "Total entries" to the year page

### DIFF
--- a/world_stage/routes/year.py
+++ b/world_stage/routes/year.py
@@ -70,10 +70,7 @@ def year(year: str):
 
         cursor.execute('SELECT COUNT(*) FROM song WHERE year_id = ? AND is_placeholder = 0', (_year,))
         total_entries = cursor.fetchone()[0]
-
-        cursor.execute('SELECT COUNT(*) FROM song WHERE year_id = ? AND is_placeholder = 1', (_year,))
-        total_placeholders = cursor.fetchone()[0]
-
+        total_placeholders = len(songs)-total_entries
         cursor.execute('SELECT short_name, show_name, date FROM show WHERE year_id = ?', (year,))
         shows = [Show(year=_year, short_name=show[0], name=show[1], date=show[2]) for show in cursor.fetchall()]
         shows.sort()

--- a/world_stage/routes/year.py
+++ b/world_stage/routes/year.py
@@ -68,11 +68,17 @@ def year(year: str):
 
         songs = get_year_songs(_year, select_languages=True)
 
+        cursor.execute('SELECT COUNT(*) FROM song WHERE year_id = ? AND is_placeholder = 0', (_year,))
+        total_entries = cursor.fetchone()[0]
+
+        cursor.execute('SELECT COUNT(*) FROM song WHERE year_id = ? AND is_placeholder = 1', (_year,))
+        total_placeholders = cursor.fetchone()[0]
+
         cursor.execute('SELECT short_name, show_name, date FROM show WHERE year_id = ?', (year,))
         shows = [Show(year=_year, short_name=show[0], name=show[1], date=show[2]) for show in cursor.fetchall()]
         shows.sort()
 
-        return render_template('year/year.html', year=year, songs=songs, closed=closed[0], shows=shows)
+        return render_template('year/year.html', year=year, songs=songs, closed=closed[0], shows=shows, total=total_entries, placeholders=total_placeholders)
     else:
         return render_template('year/specials.html', specials=get_specials())
 

--- a/world_stage/templates/year/year.html
+++ b/world_stage/templates/year/year.html
@@ -25,6 +25,9 @@
     <input type="checkbox" id="hidesolid" onchange="hideNonPlaceholders(this)">
     <label for="hidesolid">Only show placeholders</label>
 </div>
+<div>
+    <strong><big>Total entries:{{total}} ({{placeholders}} placeholders)</big></strong>
+</div>
 
 <table class="songs-table sortable">
     <thead>


### PR DESCRIPTION
Adds an entry for total number of entries of each year + the number of placeholders. 

The "Total entries" value only includes entries that aren't placeholder. 

![image](https://github.com/user-attachments/assets/7cbba75d-c530-44c0-ab76-fe74ebf1126c)
